### PR TITLE
Allow @api tag in class comment

### DIFF
--- a/Jh/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Jh/Sniffs/Commenting/ClassCommentSniff.php
@@ -21,6 +21,7 @@ class ClassCommentSniff implements Sniff
         '@magentoConfigFixture',
         '@magentoAppArea',
         '@magentoAppIsolation',
+        '@api',
     ];
 
     public function register()


### PR DESCRIPTION
 Fixing @api tag is not allowed in class comment (Jh.Commenting.ClassComment.TagNotAllowed)