### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1
+FROM php:7.1-alpine
 
 ENV CODESNIFFER_VERSION 3.2.3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:7.1
+
+ENV CODESNIFFER_VERSION 3.2.3
+
+RUN curl \
+        -L \
+        -o /usr/local/bin/phpcs \
+        "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/$CODESNIFFER_VERSION/phpcs.phar" \
+    && chmod +x /usr/local/bin/phpcs
+
+RUN curl \
+        -L \
+        -o /usr/local/bin/phpcbf \
+        "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/$CODESNIFFER_VERSION/phpcbf.phar" \
+    && chmod +x /usr/local/bin/phpcs
+
+COPY Jh /etc/coding-standard/Jh
+
+CMD ["/usr/local/bin/phpcs", "--standard=/etc/coding-standard/Jh", "-s", "/mnt"]


### PR DESCRIPTION
I wrote a long PR message explaining how to use this and the internet crapped out and I lost it. We can add this to our module Composer manifests to lint code without any dependencies:

```
  "scripts": {
      "lint": "docker run --rm --volume=\"$(pwd):/mnt\" wearejh/php-coding-standards:latest",
      "fix": "docker run --rm --volume=\"$(pwd):/mnt\" wearejh/php-coding-standards:latest phpcbf -s /mnt --standard=/etc/coding-standard/Jh"
  },
```

Which is cool.