### PR TITLE
Fix exclusions in the coding standard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN curl \
 
 COPY Jh /etc/coding-standard/Jh
 
-CMD ["/usr/local/bin/phpcs", "--standard=/etc/coding-standard/Jh", "-s", "/mnt"]
+CMD ["/usr/local/bin/phpcs", "--standard=/etc/coding-standard/Jh", "--extensions=php", "-s", "/mnt"]


### PR DESCRIPTION
We had an issue where running the `composer run lint` command would lint JS files. Turns out PHPCS does that too, but we're not ready to teach FE to code yet, so we'll leave it out.