### PR TITLE
make class doc comment optional

### DIFF
--- a/Jh/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Jh/Sniffs/Commenting/ClassCommentSniff.php
@@ -42,7 +42,6 @@ class ClassCommentSniff implements Sniff
         if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
             && $tokens[$commentEnd]['code'] !== T_COMMENT
         ) {
-            $phpCsFile->addError('Missing class doc comment', $stackPtr, 'Missing');
             $phpCsFile->recordMetric($stackPtr, 'Class has doc comment', 'no');
             return;
         }


### PR DESCRIPTION
Since `@author` has been made an optional attribute, there's no real reason to have class doc comments be required.