### PR TITLE
Add rule to align adjacent statements

### DIFF
--- a/Jh/ruleset.xml
+++ b/Jh/ruleset.xml
@@ -19,4 +19,10 @@
         <severity>5</severity>
     </rule>
     <rule ref="Generic.PHP.RequireStrictTypes"/>
+    <rule ref="Generic.Formatting.MultipleStatementAlignment">
+        <properties>
+            <property name="maxPadding" value="50"/>
+            <property name="error" value="true"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
Adds rule to stop the following 
```
    const NUMBER_1   = 100;
    const NUMBER_20  = 200;
    
    const NUMBER_220000         = 100;
    const NUMBER_23000 =       200;
```
Phpstorm allows you to enable this feature but this PR moves this depedency on using phpstorm to coding standards, allowing any codebase using the JH coding standards to enforce and fix without the use of an editor such as phpstorm.
